### PR TITLE
Removing restart limit

### DIFF
--- a/assets/rpi_screenbrightness_mqtt.service
+++ b/assets/rpi_screenbrightness_mqtt.service
@@ -1,13 +1,12 @@
 [Unit]
 Description=RasPi Sceeen Brightness Control MQTT
 After=network.target
-StartLimitBurst=3
-StartLimitIntervalSec=10
 
 [Service]
 Type=simple
 ExecStart=python3 -u -m rpi_screenbrightness_mqtt.run
 Restart=always
+RestartSec=3
 User=root
 
 [Install]


### PR DESCRIPTION
When broker is missing the service fails. To ensure that the service will come back online automaticly, and ease on the restart interval, changes in restart interval was made, and removing the restart limit.